### PR TITLE
Fix for random failure in getting rotation vector data

### DIFF
--- a/services/sensorservice/SensorService.cpp
+++ b/services/sensorservice/SensorService.cpp
@@ -92,6 +92,14 @@ void SensorService::onFirstRef()
 
             mLastEventSeen.setCapacity(count);
             for (ssize_t i=0 ; i<count ; i++) {
+                // For OnePlus2, use AOSP based fusion sensor instead of
+                // hardware sensor for rotation vector
+                // FIXME: This behavior should kick in only for OnePlus2
+                // and we need to find an appropriate preprocessor macor
+                if (SENSOR_TYPE_ROTATION_VECTOR == list[i].type) {
+                    continue;
+                }
+
                 registerSensor( new HardwareSensor(list[i]) );
                 switch (list[i].type) {
                     case SENSOR_TYPE_ACCELEROMETER:


### PR DESCRIPTION
Have tried something similar in Paranoid Android and it works. Since I do not have the resources to setup CM build, request someone to kindly take this forward. Since I am behind a firewall, unable to push for review
The diff based on PA source: http://pastebin.com/x9mMHzaq
XDA thread: http://forum.xda-developers.com/showpost.php?p=68314327&postcount=636
